### PR TITLE
Added dependency on msvcrt and changes snprintf and stat calls to their ...

### DIFF
--- a/cbits/HsUname.c
+++ b/cbits/HsUname.c
@@ -22,7 +22,7 @@ static void StringCchCat(char *dest, size_t bufsize, const char *src)
     strcat(dest, src);
 }
 
-#define StringCchPrintf snprintf
+#define StringCchPrintf _snprintf
 
 #endif
 

--- a/cbits/mktemp.c
+++ b/cbits/mktemp.c
@@ -104,7 +104,7 @@ static int _gettemp(char *path, int *doopen)
         for (; trv > path; --trv) {
             if (*trv == '/') {
                 *trv = '\0';
-                rval = stat(path, &sbuf);
+                rval = _stat(path, &sbuf);
                 *trv = '/';
                 if (rval != 0)
                     return (0);
@@ -124,7 +124,7 @@ static int _gettemp(char *path, int *doopen)
                 return (1);
             if (errno != EEXIST)
                 return (0);
-        } else if (stat(path, &sbuf))
+        } else if (_stat(path, &sbuf))
             return (errno == ENOENT);
 
         /* If we have a collision, cycle through the space of filenames */

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -43,6 +43,8 @@ Library
       cbits/HsUname.c
       cbits/mktemp.c
 
+    extra-libraries: msvcrt
+
     if flag(old-time)
       build-depends: old-time >= 1.0.0.0 && < 1.2.0.0
       cpp-options: -DOLD_TIME


### PR DESCRIPTION
Hi!

I've noted some annoying effect working with my code that depends on unix-compat via third libraries. Currently I'm developing on Windows. My code builds into an executeable and works just fine; however when it comes to debugging and REPL, - GHCi refuses to load unix-compat library complaining on the absence of snprintf symbol:
"""
ghc.exe: (skipped).cabal-sandbox\x86_64-windows-ghc-7.8.2\unix-compat-0.4.1.1\HSunix-compat-0.4.1.1.o: unknown symbol `snprintf'
ghc.exe: unable to load package`unix-compat-0.4.1.1'
"""

I think that's because in typical Win32 build environment snprintf resides in libmingwex.a (please correct me if I'm wrong), which is static library, which GHCi is incapable of loading (that's my suspicion again). My pull request contains a few changes switching the missing calls to MSVCRT implementations, which is dynamic library, and it allows GHCi to find missing symbols. 

Could you possibly just take a look at my changes and maybe tell how deeply wrong they are and why, please? I'm far from thinking those changes are correct because
- they introduce new unexpected dependency (even though MSVCRT is always present in Windows system these days);
- I see the #ifdef _MSC_VER in HsUname.c - and realize that I don't even know how to compile a Haskell library using Microsoft C compiler;
- generally I'm not experienced with MinGW build environment - so I'm not sure that there is no other way to make the missing symbols visible to GHCi.

Having in mind what's said above, - the changes might be considered as a working solution though. At least I've tested them with my current project and they worked - both in "cabal build" and "cabal repl" cases.

GHC(i) 7.8.2.
