### PR TITLE
Fix sysmacros.h include for non-glibc libcs

### DIFF
--- a/cbits/HsUnixCompat.c
+++ b/cbits/HsUnixCompat.c
@@ -2,7 +2,7 @@
 
 #ifdef SOLARIS
 #include <sys/mkdev.h>
-#elif defined(__GLIBC__)
+#elif defined(__linux__)
 #include <sys/sysmacros.h>
 #endif
 


### PR DESCRIPTION
A while ago glibc stopped including this from `sys/types.h` so this explicit include was added. The `musl` libc has since followed suit and stopped including this header in `sys/types.h`, therefore it's also necessary to do this.

These `major`/`minor` macros are not a part of POSIX or any other standard, therefore since we're already using them, it's probably safe to assume the same header will also be used.

This fixes build of several haskell software for `musl` in our distribution (@void-linux).

Also, while at it, would it be possible to publish a new release with the fix ideally as soon as possible? That would make it a lot easier to fix the broken software in the distro (since it won't need manual patching of every single thing, just a simple version bump).

Thanks!