### PR TITLE
partial support for high resolution timestamps, drop definition of FileID

### DIFF
--- a/src/System/PosixCompat/Internal/Time.hs
+++ b/src/System/PosixCompat/Internal/Time.hs
@@ -7,8 +7,6 @@ module System.PosixCompat.Internal.Time (
       ClockTime
     , getClockTime
     , clockTimeToEpochTime
-    , ModificationTime
-    , modificationTimeToEpochTime
     ) where
 
 import System.Posix.Types (EpochTime)
@@ -20,15 +18,9 @@ import System.Time (ClockTime(TOD), getClockTime)
 clockTimeToEpochTime :: ClockTime -> EpochTime
 clockTimeToEpochTime (TOD s _) = fromInteger s
 
-type ModificationTime = ClockTime
-
-modificationTimeToEpochTime :: ModificationTime -> EpochTime
-modificationTimeToEpochTime = clockTimeToEpochTime
-
 #else
 
-import Data.Time.Clock (UTCTime)
-import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime, utcTimeToPOSIXSeconds)
+import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
 
 type ClockTime = POSIXTime
 
@@ -37,10 +29,5 @@ getClockTime = getPOSIXTime
 
 clockTimeToEpochTime :: ClockTime -> EpochTime
 clockTimeToEpochTime = fromInteger . floor
-
-type ModificationTime = UTCTime
-
-modificationTimeToEpochTime :: UTCTime -> EpochTime
-modificationTimeToEpochTime = clockTimeToEpochTime . utcTimeToPOSIXSeconds
 
 #endif

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -8,14 +8,11 @@ On Windows 'UserID', 'GroupID' and 'LinkCount' are missing, so they are
 redefined by this module.
 -}
 module System.PosixCompat.Types (
+      module System.Posix.Types
 #ifdef mingw32_HOST_OS
-     module AllPosixTypesButFileID
-    , FileID
     , UserID
     , GroupID
     , LinkCount
-#else
-     module System.Posix.Types
 #endif
     ) where
 
@@ -23,15 +20,9 @@ module System.PosixCompat.Types (
 -- Since CIno (FileID's underlying type) reflects <sys/type.h> ino_t,
 -- which mingw defines as short int (int16), it must be overriden to
 -- match the size of windows fileIndex (word64).
-import System.Posix.Types as AllPosixTypesButFileID hiding (FileID)
+import System.Posix.Types
 
-import Data.Word (Word32, Word64)
-
-newtype FileID = FileID Word64
-  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
-instance Show FileID where show (FileID x) = show x
-instance Read FileID where readsPrec i s = [ (FileID x, s')
-                                           | (x,s') <- readsPrec i s]
+import Data.Word (Word32)
 
 newtype UserID = UserID Word32
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -1,5 +1,5 @@
 name:           unix-compat
-version:        0.5.2.1
+version:        0.5.3
 synopsis:       Portable POSIX-compatibility layer.
 description:    This package provides portable implementations of parts
                 of the unix package. This package re-exports the unix

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -1,5 +1,5 @@
 name:           unix-compat
-version:        0.5.2
+version:        0.5.2.1
 synopsis:       Portable POSIX-compatibility layer.
 description:    This package provides portable implementations of parts
                 of the unix package. This package re-exports the unix


### PR DESCRIPTION
The two commits in this branch are pretty much unrelated.

The first one implements support for retrieving high resolution timestamps on Windows from a FileStatus. Setting timestamps is is not done, but could be easily added (I think).

The second commit removes the definition of FileID in favour of the one from System.Posix.Types. Contrary to the comments in the code, the FileID type in System.Posix.Types is 64 bits, same as that for Windows.

We tested both features by using them in Darcs and running our extensive test suite on Windows and Linux.