### PR TITLE
Support time 1.11 and Win32 2.12

### DIFF
--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -57,7 +57,7 @@ Library
       else
         build-depends: directory == 1.1.*
     else
-      build-depends: time >= 1.0 && < 1.12
+      build-depends: time >= 1.0 && < 1.13
       build-depends: directory >= 1.2 && < 1.4
 
     other-modules:

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -57,7 +57,7 @@ Library
       else
         build-depends: directory == 1.1.*
     else
-      build-depends: time >= 1.0 && < 1.10
+      build-depends: time >= 1.0 && < 1.12
       build-depends: directory >= 1.2 && < 1.4
 
     other-modules:


### PR DESCRIPTION
Supporting time 1.11 just needed a bump on the constraint. Supporting Win32 2.12 was slightly more involved since the type signature of `setFileTime` changed. See https://github.com/haskell/win32/commit/7dfe8b3747af878ff1efef62617a35b24af3cca6. 