### PR TITLE
Remove an outdated CPP directive in User

### DIFF
--- a/src/System/PosixCompat/User.hsc
+++ b/src/System/PosixCompat/User.hsc
@@ -39,14 +39,6 @@ module System.PosixCompat.User (
 
 import System.Posix.User
 
-#if __GLASGOW_HASKELL__<605
-getAllGroupEntries :: IO [GroupEntry]
-getAllGroupEntries = return []
-
-getAllUserEntries :: IO [UserEntry]
-getAllUserEntries = return []
-#endif
-
 #else /* Portable implementation */
 
 import System.IO.Error


### PR DESCRIPTION
The current unix-compat is built with unix >=2.6, and all version of these packages exposes getAllGroupEntries and getAllUserEntries. So we no longer need to define dummy implementations.