### PR TITLE
Add new testsuite to check types of System.Posix.Types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
         ghc:
           - 8.8.4
           - 8.10.7
-          - 9.0.1
-          - 9.2.1
+          - 9.0.2
+          - 9.2.4
       fail-fast: false
     continue-on-error: ${{ startsWith(matrix.os, 'windows') && startsWith(matrix.ghc, '9.2') }}
     

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 .ghc.*
 .stack-work
+cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: ./unix-compat.cabal

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -37,7 +37,7 @@ module System.PosixCompat.Types (
 #endif
     ) where
 
-import Data.Int (Int64)
+import Data.Int (Int32, Int64)
 import Data.Word (Word8, Word32, Word64)
 import Foreign (Ptr)
 import System.Posix.Types

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -19,6 +19,12 @@ module System.PosixCompat.Types (
     , CCc(..)
     , CFsBlkCnt(..)
     , CFsFilCnt(..)
+    , CId(..)
+    , CKey(..)
+    , CRLim(..)
+    , CSpeed(..)
+    , CTcFlag(..)
+    , CTimer(..)
     , UserID
     , CUid(..)
     , GroupID
@@ -80,6 +86,40 @@ newtype CFsFilCnt = CFsFilCnt Word64
 instance Show CFsFilCnt where show (CFsFilCnt x) = show x
 instance Read CFsFilCnt where readsPrec i s = [ (CFsFilCnt x, s')
                                             | (x,s') <- readsPrec i s]
+
+newtype CId = CId Word32
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CId where show (CId x) = show x
+instance Read CId where readsPrec i s = [ (CId x, s')
+                                      | (x,s') <- readsPrec i s]
+
+newtype CKey = CId Int32
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CKey where show (CKey x) = show x
+instance Read CKey where readsPrec i s = [ (CKey x, s')
+                                       | (x,s') <- readsPrec i s]
+
+newtype CRLim = CRLim Word64
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CRLim where show (CRLim x) = show x
+instance Read CRLim where readsPrec i s = [ (CRLim x, s')
+                                        | (x,s') <- readsPrec i s]
+
+newtype CSpeed = CSpeed Word32
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CSpeed where show (CSpeed x) = show x
+instance Read CSpeed where readsPrec i s = [ (CSpeed x, s')
+                                        | (x,s') <- readsPrec i s]
+
+newtype CTcflag = CTcflag Word32
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CTcflag where show (CTcflag x) = show x
+instance Read CTcflag where readsPrec i s = [ (CTcflag x, s')
+                                        | (x,s') <- readsPrec i s]
+
+newtype CTimer = CTimer (Ptr ())
+  deriving (Eq, Ord)
+instance Show CTimer where show (CTimer x) = show x
 
 type UserID = CUid
 

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -32,7 +32,7 @@ module System.PosixCompat.Types (
     , LinkCount
     , CNlink(..)
 #endif
-#if !MIN_VERSION_base(4, 14, 0)
+#if defined mingw32_HOST_OS || !MIN_VERSION_base(4, 14, 0)
     , CNfds(..)
     , CSocklen(..)
 #endif

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -19,7 +19,6 @@ module System.PosixCompat.Types (
     , CCc(..)
     , CFsBlkCnt(..)
     , CFsFilCnt(..)
-    , CId(..)
     , CKey(..)
     , CRLim(..)
     , CSpeed(..)
@@ -32,8 +31,7 @@ module System.PosixCompat.Types (
     , LinkCount
     , CNlink(..)
 #endif
-#if MIN_VERSION_base(4, 14, 3)
-#else
+#if !MIN_VERSION_base(4, 14, 3)
     , CNfds(..)
     , CSocklen(..)
 #endif
@@ -86,12 +84,6 @@ newtype CFsFilCnt = CFsFilCnt Word64
 instance Show CFsFilCnt where show (CFsFilCnt x) = show x
 instance Read CFsFilCnt where readsPrec i s = [ (CFsFilCnt x, s')
                                             | (x,s') <- readsPrec i s]
-
-newtype CId = CId Word32
-  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
-instance Show CId where show (CId x) = show x
-instance Read CId where readsPrec i s = [ (CId x, s')
-                                      | (x,s') <- readsPrec i s]
 
 newtype CKey = CId Int32
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
@@ -147,8 +139,7 @@ instance Read CNlink where readsPrec i s = [ (CNlink x, s')
 
 #endif
 
-#if MIN_VERSION_base(4, 14, 3)
-#else
+#if !MIN_VERSION_base(4, 14, 3)
 
 newtype CNfds = CNfds Word64
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -3,45 +3,100 @@
 
 {-|
 This module re-exports the types from @System.Posix.Types@ on all platforms.
-
-On Windows 'UserID', 'GroupID' and 'LinkCount' are missing, so they are
-redefined by this module.
+It defines drop-in replacements for types that are missing from that module on a
+specific OS. Namely Mac OS and Windows are supported.
 -}
 module System.PosixCompat.Types (
       module System.Posix.Types
+#ifdef darwin_HOST_OS
+    , CTimer(..)
+#endif
 #ifdef mingw32_HOST_OS
+    , CBlkCnt(..)
+    , CBlkSize(..)
+    , CCc(..)
+    , CFsBlkCnt(..)
+    , CFsFilCnt(..)
     , UserID
+    , CUid(..)
     , GroupID
+    , CGid(..)
     , LinkCount
+    , CNlink(..)
 #endif
     ) where
 
+import System.Posix.Types
+
+#ifdef darwin_HOST_OS
+import Foreign.C.Types (CUIntPtr)
+
+newtype CTimer = CTimer CUIntPtr
+  deriving (Eq, Ord)
+instance Show CTimer where show (CTimer x) = show x
+
+#else
 #ifdef mingw32_HOST_OS
 -- Since CIno (FileID's underlying type) reflects <sys/type.h> ino_t,
 -- which mingw defines as short int (int16), it must be overriden to
 -- match the size of windows fileIndex (word64).
-import System.Posix.Types
 
-import Data.Word (Word32)
+import Data.Int (Int64)
+import Data.Word (Word8, Word32, Word64)
 
-newtype UserID = UserID Word32
+newtype CBlkCnt = CBlkCnt Int64
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
-instance Show UserID where show (UserID x) = show x
-instance Read UserID where readsPrec i s = [ (UserID x, s')
+instance Show CBlkCnt where show (CBlkCnt x) = show x
+instance Read CBlkCnt where readsPrec i s = [ (CBlkCnt x, s')
+                                          | (x,s') <- readsPrec i s]
+
+newtype CBlkSize = CBlkSize Int64
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CBlkSize where show (CBlkSize x) = show x
+instance Read CBlkSize where readsPrec i s = [ (CBlkSize x, s')
                                            | (x,s') <- readsPrec i s]
 
-newtype GroupID = GroupID Word32
+newtype CCc = Ccs Word8
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
-instance Show GroupID where show (GroupID x) = show x
-instance Read GroupID where readsPrec i s = [ (GroupID x, s')
+instance Show CCc where show (CCc x) = show x
+instance Read CCc where readsPrec i s = [ (CCc x, s')
+                                      | (x,s') <- readsPrec i s]
+
+newtype CFsBlkCnt = CFsBlkCnt Word64
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CFsBlkCnt where show (CFsBlkCnt x) = show x
+instance Read CFsBlkCnt where readsPrec i s = [ (CFsBlkCnt x, s')
                                             | (x,s') <- readsPrec i s]
 
-newtype LinkCount = LinkCount Word32
+newtype CFsFilCnt = CFsFilCnt Word64
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
-instance Show LinkCount where show (LinkCount x) = show x
-instance Read LinkCount where readsPrec i s = [ (LinkCount x, s')
-                                              | (x,s') <- readsPrec i s]
+instance Show CFsFilCnt where show (CFsFilCnt x) = show x
+instance Read CFsFilCnt where readsPrec i s = [ (CFsFilCnt x, s')
+                                            | (x,s') <- readsPrec i s]
 
-#else
-import System.Posix.Types
+type UserID = UserID CUid
+
+newtype CUid = CUid Word32
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CUid where show (CUid x) = show x
+instance Read CUid where readsPrec i s = [ (CUid x, s')
+                                         | (x,s') <- readsPrec i s]
+
+type GroupID = CGid
+
+newtype CGid = CGid Word32
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CGid where show (CGid x) = show x
+instance Read CGid where readsPrec i s = [ (CGid x, s')
+                                         | (x,s') <- readsPrec i s]
+
+type LinkCount = CNlink
+
+newtype CNlink = CNlink Word64
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CNlink where show (CNlink x) = show x
+instance Read CNlink where readsPrec i s = [ (CNlink x, s')
+                                           | (x,s') <- readsPrec i s]
+
+#endif
 #endif

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -35,7 +35,7 @@ module System.PosixCompat.Types (
 
 import Data.Int (Int64)
 import Data.Word (Word8, Word32, Word64)
-import Foreign.C.Types (CUIntPtr)
+import Foreign (Ptr)
 import System.Posix.Types
 
 #ifdef darwin_HOST_OS

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -22,7 +22,7 @@ module System.PosixCompat.Types (
     , CKey(..)
     , CRLim(..)
     , CSpeed(..)
-    , CTcFlag(..)
+    , CTcflag(..)
     , CTimer(..)
     , UserID
     , CUid(..)

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
 {-|
 This module re-exports the types from @System.Posix.Types@ on all platforms.
 It defines drop-in replacements for types that are missing from that module on a
@@ -24,25 +26,30 @@ module System.PosixCompat.Types (
     , LinkCount
     , CNlink(..)
 #endif
+#if MIN_VERSION_base(4, 14, 3)
+#else
+    , CNfds(..)
+    , CSocklen(..)
+#endif
     ) where
 
+import Data.Int (Int64)
+import Data.Word (Word8, Word32, Word64)
+import Foreign.C.Types (CUIntPtr)
 import System.Posix.Types
 
 #ifdef darwin_HOST_OS
-import Foreign.C.Types (CUIntPtr)
 
 newtype CTimer = CTimer CUIntPtr
   deriving (Eq, Ord)
 instance Show CTimer where show (CTimer x) = show x
 
-#else
+#endif
+
 #ifdef mingw32_HOST_OS
 -- Since CIno (FileID's underlying type) reflects <sys/type.h> ino_t,
 -- which mingw defines as short int (int16), it must be overriden to
 -- match the size of windows fileIndex (word64).
-
-import Data.Int (Int64)
-import Data.Word (Word8, Word32, Word64)
 
 newtype CBlkCnt = CBlkCnt Int64
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
@@ -56,7 +63,7 @@ instance Show CBlkSize where show (CBlkSize x) = show x
 instance Read CBlkSize where readsPrec i s = [ (CBlkSize x, s')
                                            | (x,s') <- readsPrec i s]
 
-newtype CCc = Ccs Word8
+newtype CCc = CCc Word8
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
 instance Show CCc where show (CCc x) = show x
 instance Read CCc where readsPrec i s = [ (CCc x, s')
@@ -99,4 +106,20 @@ instance Read CNlink where readsPrec i s = [ (CNlink x, s')
                                            | (x,s') <- readsPrec i s]
 
 #endif
+
+#if MIN_VERSION_base(4, 14, 3)
+#else
+
+newtype CNfds = CNfds Word64
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CNfds where show (CNfds x) = show x
+instance Read CNfds where readsPrec i s = [ (CNfds x, s')
+                                          | (x,s') <- readsPrec i s]
+
+newtype CSocklen = CSocklen Word32
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CSocklen where show (CSocklen x) = show x
+instance Read CSocklen where readsPrec i s = [ (CSocklen x, s')
+                                             | (x,s') <- readsPrec i s]
+
 #endif

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -85,7 +85,7 @@ instance Show CFsFilCnt where show (CFsFilCnt x) = show x
 instance Read CFsFilCnt where readsPrec i s = [ (CFsFilCnt x, s')
                                             | (x,s') <- readsPrec i s]
 
-newtype CKey = CId Int32
+newtype CKey = CKey Int32
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
 instance Show CKey where show (CKey x) = show x
 instance Read CKey where readsPrec i s = [ (CKey x, s')

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -32,7 +32,7 @@ module System.PosixCompat.Types (
     , LinkCount
     , CNlink(..)
 #endif
-#if !MIN_VERSION_base(4, 14, 3)
+#if !MIN_VERSION_base(4, 14, 0)
     , CNfds(..)
     , CSocklen(..)
 #endif
@@ -146,7 +146,7 @@ instance Read CNlink where readsPrec i s = [ (CNlink x, s')
 
 #endif
 
-#if !MIN_VERSION_base(4, 14, 3)
+#if defined mingw32_HOST_OS || !MIN_VERSION_base(4, 14, 0)
 
 newtype CNfds = CNfds Word64
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -19,6 +19,7 @@ module System.PosixCompat.Types (
     , CCc(..)
     , CFsBlkCnt(..)
     , CFsFilCnt(..)
+    , CId(..)
     , CKey(..)
     , CRLim(..)
     , CSpeed(..)
@@ -84,6 +85,12 @@ newtype CFsFilCnt = CFsFilCnt Word64
 instance Show CFsFilCnt where show (CFsFilCnt x) = show x
 instance Read CFsFilCnt where readsPrec i s = [ (CFsFilCnt x, s')
                                             | (x,s') <- readsPrec i s]
+
+newtype CId = CId Word32
+  deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)
+instance Show CId where show (CId x) = show x
+instance Read CId where readsPrec i s = [ (CId x, s')
+                                      | (x,s') <- readsPrec i s]
 
 newtype CKey = CKey Int32
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)

--- a/src/System/PosixCompat/Types.hs
+++ b/src/System/PosixCompat/Types.hs
@@ -40,7 +40,7 @@ import System.Posix.Types
 
 #ifdef darwin_HOST_OS
 
-newtype CTimer = CTimer CUIntPtr
+newtype CTimer = CTimer (Ptr ())
   deriving (Eq, Ord)
 instance Show CTimer where show (CTimer x) = show x
 
@@ -81,7 +81,7 @@ instance Show CFsFilCnt where show (CFsFilCnt x) = show x
 instance Read CFsFilCnt where readsPrec i s = [ (CFsFilCnt x, s')
                                             | (x,s') <- readsPrec i s]
 
-type UserID = UserID CUid
+type UserID = CUid
 
 newtype CUid = CUid Word32
   deriving (Eq, Ord, Enum, Bounded, Integral, Num, Real)

--- a/tests/check-types.hs
+++ b/tests/check-types.hs
@@ -36,6 +36,8 @@ newtypeCClockId (CClockId x) = x
 
 #ifdef darwin_HOST_OS
 newtypeCDev :: CDev -> Int32
+#elif defined mingw32_HOST_OS
+newtypeCDev :: CDev -> Word32
 #else
 newtypeCDev :: CDev -> Word64
 #endif
@@ -61,13 +63,19 @@ newtypeCGid (CGid x) = x
 newtypeCId :: CId -> Word32
 newtypeCId (CId x) = x
 
+#ifdef mingw32_HOST_OS
+newtypeCIno :: CIno -> Word16
+#else
 newtypeCIno :: CIno -> Word64
+#endif
 newtypeCIno (CIno x) = x
 
 newtypeCKey :: CKey -> Int32
 newtypeCKey (CKey x) = x
 
 #ifdef darwin_HOST_OS
+newtypeCMode :: CMode -> Word16
+#elif defined mingw32_HOST_OS
 newtypeCMode :: CMode -> Word16
 #else
 newtypeCMode :: CMode -> Word32
@@ -91,7 +99,11 @@ newtypeCNlink (CNlink x) = x
 newtypeCOff :: COff -> Int64
 newtypeCOff (COff x) = x
 
+#ifdef mingw32_HOST_OS
+newtypeCPid :: CPid -> Int64
+#else
 newtypeCPid :: CPid -> Int32
+#endif
 newtypeCPid (CPid x) = x
 
 newtypeCRLim :: CRLim -> Word64

--- a/tests/check-types.hs
+++ b/tests/check-types.hs
@@ -51,6 +51,9 @@ newtypeCKey (CKey x) = x
 newtypeCMode :: CMode -> Word32
 newtypeCMode (CMode x) = x
 
+newtypeCNfds :: CNfds -> Word64
+newtypeCNfds (CNfds x) = x
+
 newtypeCNlink :: CNlink -> Word64
 newtypeCNlink (CNlink x) = x
 
@@ -62,6 +65,9 @@ newtypeCPid (CPid x) = x
 
 newtypeCRLim :: CRLim -> Word64
 newtypeCRLim (CRLim x) = x
+
+newtypeCSocklen :: CSocklen -> Word32
+newtypeCSocklen (CSocklen x) = x
 
 newtypeCSpeed :: CSpeed -> Word32
 newtypeCSpeed (CSpeed x) = x
@@ -120,12 +126,4 @@ typeProcessID = id
 typeUserID :: UserID -> CUid
 typeUserID = id
 
-#if MIN_VERSION_base(4, 14, 3)
-newtypeCNfds :: CNfds -> Word64
-newtypeCNfds (CNfds x) = x
-
-newtypeCSocklen :: CSocklen -> Word32
-newtypeCSocklen (CSocklen x) = x
-
-#endif
 #endif

--- a/tests/check-types.hs
+++ b/tests/check-types.hs
@@ -14,26 +14,45 @@ import qualified Foreign.C.Types
 main :: IO ()
 main = pure ()
 
-#if MIN_VERSION_base(4, 13, 0)
 newtypeCBlkCnt :: CBlkCnt -> Int64
 newtypeCBlkCnt (CBlkCnt x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCBlkSize :: CBlkSize -> Int32
+#else
 newtypeCBlkSize :: CBlkSize -> Int64
+#endif
 newtypeCBlkSize (CBlkSize x) = x
 
 newtypeCCc :: CCc -> Word8
 newtypeCCc (CCc x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCClockId :: CClockId -> Word32
+#else
 newtypeCClockId :: CClockId -> Int32
+#endif
 newtypeCClockId (CClockId x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCDev :: CDev -> Int32
+#else
 newtypeCDev :: CDev -> Word64
+#endif
 newtypeCDev (CDev x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCFsBlkCnt :: CFsBlkCnt -> Word32
+#else
 newtypeCFsBlkCnt :: CFsBlkCnt -> Word64
+#endif
 newtypeCFsBlkCnt (CFsBlkCnt x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCFsFilCnt :: CFsFilCnt -> Word32
+#else
 newtypeCFsFilCnt :: CFsFilCnt -> Word64
+#endif
 newtypeCFsFilCnt (CFsFilCnt x) = x
 
 newtypeCGid :: CGid -> Word32
@@ -48,13 +67,21 @@ newtypeCIno (CIno x) = x
 newtypeCKey :: CKey -> Int32
 newtypeCKey (CKey x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCMode :: CMode -> Word16
+#else
 newtypeCMode :: CMode -> Word32
+#endif
 newtypeCMode (CMode x) = x
 
 newtypeCNfds :: CNfds -> Word64
 newtypeCNfds (CNfds x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCNlink :: CNlink -> Word16
+#else
 newtypeCNlink :: CNlink -> Word64
+#endif
 newtypeCNlink (CNlink x) = x
 
 newtypeCOff :: COff -> Int64
@@ -69,13 +96,21 @@ newtypeCRLim (CRLim x) = x
 newtypeCSocklen :: CSocklen -> Word32
 newtypeCSocklen (CSocklen x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCSpeed :: CSpeed -> Word64
+#else
 newtypeCSpeed :: CSpeed -> Word32
+#endif
 newtypeCSpeed (CSpeed x) = x
 
 newtypeCSsize :: CSsize -> Int64
 newtypeCSsize (CSsize x) = x
 
+#ifdef darwin_HOST_OS
+newtypeCTcflag :: CTcflag -> Word64
+#else
 newtypeCTcflag :: CTcflag -> Word32
+#endif
 newtypeCTcflag (CTcflag x) = x
 
 newtypeCTimer :: CTimer -> Foreign.Ptr ()
@@ -125,5 +160,3 @@ typeProcessID = id
 
 typeUserID :: UserID -> CUid
 typeUserID = id
-
-#endif

--- a/tests/check-types.hs
+++ b/tests/check-types.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+module Main (main) where
+
+import Data.Int
+import Data.Word
+import System.PosixCompat.Types
+
+import qualified Foreign
+import qualified Foreign.C.Types
+
+main :: IO ()
+main = pure ()
+
+#if MIN_VERSION_base(4, 13, 0)
+newtypeCBlkCnt :: CBlkCnt -> Int64
+newtypeCBlkCnt (CBlkCnt x) = x
+
+newtypeCBlkSize :: CBlkSize -> Int64
+newtypeCBlkSize (CBlkSize x) = x
+
+newtypeCCc :: CCc -> Word8
+newtypeCCc (CCc x) = x
+
+newtypeCClockId :: CClockId -> Int32
+newtypeCClockId (CClockId x) = x
+
+newtypeCDev :: CDev -> Word64
+newtypeCDev (CDev x) = x
+
+newtypeCFsBlkCnt :: CFsBlkCnt -> Word64
+newtypeCFsBlkCnt (CFsBlkCnt x) = x
+
+newtypeCFsFilCnt :: CFsFilCnt -> Word64
+newtypeCFsFilCnt (CFsFilCnt x) = x
+
+newtypeCGid :: CGid -> Word32
+newtypeCGid (CGid x) = x
+
+newtypeCId :: CId -> Word32
+newtypeCId (CId x) = x
+
+newtypeCIno :: CIno -> Word64
+newtypeCIno (CIno x) = x
+
+newtypeCKey :: CKey -> Int32
+newtypeCKey (CKey x) = x
+
+newtypeCMode :: CMode -> Word32
+newtypeCMode (CMode x) = x
+
+newtypeCNlink :: CNlink -> Word64
+newtypeCNlink (CNlink x) = x
+
+newtypeCOff :: COff -> Int64
+newtypeCOff (COff x) = x
+
+newtypeCPid :: CPid -> Int32
+newtypeCPid (CPid x) = x
+
+newtypeCRLim :: CRLim -> Word64
+newtypeCRLim (CRLim x) = x
+
+newtypeCSpeed :: CSpeed -> Word32
+newtypeCSpeed (CSpeed x) = x
+
+newtypeCSsize :: CSsize -> Int64
+newtypeCSsize (CSsize x) = x
+
+newtypeCTcflag :: CTcflag -> Word32
+newtypeCTcflag (CTcflag x) = x
+
+newtypeCTimer :: CTimer -> Foreign.Ptr ()
+newtypeCTimer (CTimer x) = x
+
+newtypeCUid :: CUid -> Word32
+newtypeCUid (CUid x) = x
+
+newtypeFd :: Fd -> Foreign.C.Types.CInt
+newtypeFd (Fd x) = x
+
+typeByteCount :: ByteCount -> Foreign.C.Types.CSize
+typeByteCount = id
+
+typeClockTick :: ClockTick -> Foreign.C.Types.CClock
+typeClockTick = id
+
+typeDeviceID :: DeviceID -> CDev
+typeDeviceID = id
+
+typeEpochTime :: EpochTime -> Foreign.C.Types.CTime
+typeEpochTime = id
+
+typeFileID :: FileID -> CIno
+typeFileID = id
+
+typeFileMode :: FileMode -> CMode
+typeFileMode = id
+
+typeFileOffset :: FileOffset -> COff
+typeFileOffset = id
+
+typeGroupID :: GroupID -> CGid
+typeGroupID = id
+
+typeLimit :: Limit -> Foreign.C.Types.CLong
+typeLimit = id
+
+typeLinkCount :: LinkCount -> CNlink
+typeLinkCount = id
+
+typeProcessGroupID :: ProcessGroupID -> CPid
+typeProcessGroupID = id
+
+typeProcessID :: ProcessID -> CPid
+typeProcessID = id
+
+typeUserID :: UserID -> CUid
+typeUserID = id
+
+#if MIN_VERSION_base(4, 14, 3)
+newtypeCNfds :: CNfds -> Word64
+newtypeCNfds (CNfds x) = x
+
+newtypeCSocklen :: CSocklen -> Word32
+newtypeCSocklen (CSocklen x) = x
+
+#endif
+#endif

--- a/tests/check-types.hs
+++ b/tests/check-types.hs
@@ -74,7 +74,11 @@ newtypeCMode :: CMode -> Word32
 #endif
 newtypeCMode (CMode x) = x
 
+#if defined darwin_HOST_OS && MIN_VERSION_base(4,14,0)
+newtypeCNfds :: CNfds -> Word32
+#else
 newtypeCNfds :: CNfds -> Word64
+#endif
 newtypeCNfds (CNfds x) = x
 
 #ifdef darwin_HOST_OS

--- a/tests/check-types.hs
+++ b/tests/check-types.hs
@@ -74,7 +74,7 @@ newtypeCMode :: CMode -> Word32
 #endif
 newtypeCMode (CMode x) = x
 
-#if defined darwin_HOST_OS && MIN_VERSION_base(4,14,0)
+#if defined darwin_HOST_OS && MIN_VERSION_base(4, 14, 0)
 newtypeCNfds :: CNfds -> Word32
 #else
 newtypeCNfds :: CNfds -> Word64

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -146,3 +146,15 @@ Test-Suite unix-compat-testsuite
       cc-options: -DSOLARIS
 
     build-depends: directory >= 1.3.1 && < 1.4
+
+Test-Suite unix-compat-check-types
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  hs-source-dirs: tests
+  ghc-options: -Wall
+  main-is: check-types.hs
+
+  build-depends:
+      unix-compat
+    , base == 4.*
+


### PR DESCRIPTION
This PR adds a new testsuite `unix-compat-check-types`. Its purpose is to track the types of the numerous type and newtype declarations of `System.Posix.Types` on different OSs. The `main` function of that testsuite is a stub, success is indicated by a successful compilation of the testsuite itself. In addition to that it
 * adds several missing types for Mac OS and Windows.
 * defines `UserID`/`GroupID`/`LinkCount` in terms of `CUid`/`CGid`/`CNlink` like it is done in `System.Posix.Types`.
 * exposes all constructors of the newtypes defined `System.PosixCompat.Types`.
 * bumps the minor versions of 9.0 and 9.2 series of GHC in the CI setup.