### PR TITLE
Fix compatibilities with unix >=2.8 package

### DIFF
--- a/src/System/PosixCompat/User.hsc
+++ b/src/System/PosixCompat/User.hsc
@@ -40,7 +40,7 @@ module System.PosixCompat.User (
 
 #include "HsUnixCompat.h"
 
-#ifdef UNIX_2_8
+#if MIN_VERSION_unix(2, 8, 0)
 import System.Posix.Types (GroupID, UserID)
 import System.Posix.User
     ( getRealUserID

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -26,6 +26,9 @@ flag old-time
   description: build against old-time package
   default: False
 
+flag unix28
+  description: build against unix >= 2.8 package
+
 Library
   default-language: Haskell2010
   hs-source-dirs: src
@@ -68,7 +71,12 @@ Library
       System.PosixCompat.Internal.Time
 
   else
-    build-depends: unix >= 2.6 && < 2.9
+    if flag(unix28)
+      build-depends: unix >= 2.8 && < 2.9
+      cpp-options: -DUNIX_2_8
+    else
+      build-depends: unix >= 2.6 && < 2.8
+
     include-dirs: include
     includes: HsUnixCompat.h
     install-includes: HsUnixCompat.h

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -26,9 +26,6 @@ flag old-time
   description: build against old-time package
   default: False
 
-flag unix28
-  description: build against unix >= 2.8 package
-
 Library
   default-language: Haskell2010
   hs-source-dirs: src
@@ -71,12 +68,7 @@ Library
       System.PosixCompat.Internal.Time
 
   else
-    if flag(unix28)
-      build-depends: unix >= 2.8 && < 2.9
-      cpp-options: -DUNIX_2_8
-    else
-      build-depends: unix >= 2.6 && < 2.8
-
+    build-depends: unix >= 2.6 && < 2.9
     include-dirs: include
     includes: HsUnixCompat.h
     install-includes: HsUnixCompat.h


### PR DESCRIPTION
Since version 2.8, the unix package changed `UserEntry` and `GroupEntry` into the `ByteString` based implementation instead of `String` as a breaking change. We can compile this package with unix >=2.8 if just re-exports the two of new data types, but it's probably uncomfortable for users because types of fields of the two isn't the same between prior 2.8 and since 2.8. So we need to define and export compatible data types for `UserEntry` and `GroupEntry` to resolve this problem.

This patch provides API compatibilities not between platforms but between versions of library, so the `compat` which this patch provide isn't probably the same as the `compat` which this package provides.

Fix #57.